### PR TITLE
Fix showing authorized agents in unauthorized part.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" />
     <option name="OPTION_SCOPE" value="protected" />
@@ -27,8 +24,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_5" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
-

--- a/server/src/jetbrains/buildServer/agentsDiff/BuildAgentsDiffTab.java
+++ b/server/src/jetbrains/buildServer/agentsDiff/BuildAgentsDiffTab.java
@@ -16,6 +16,7 @@
 
 package jetbrains.buildServer.agentsDiff;
 
+import jetbrains.buildServer.BuildAgent;
 import jetbrains.buildServer.serverSide.BuildAgentEx;
 import jetbrains.buildServer.serverSide.BuildAgentManagerEx;
 import jetbrains.buildServer.serverSide.agentTypes.AgentType;
@@ -31,9 +32,10 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static jetbrains.buildServer.util.CollectionsUtil.*;
 
@@ -63,7 +65,12 @@ public class BuildAgentsDiffTab extends SimpleCustomTab {
     super.fillModel(model, request);
     List<BuildAgentEx> authorized = myBuildAgentManager.getAllAgents(false);
     model.put("allAgents", authorized);
-    Collection<BuildAgentEx> unauthorized = new LinkedHashSet<BuildAgentEx>(myBuildAgentManager.getAllAgents(true));
+
+    final Set<Integer> authorizedIds = authorized.stream().map(BuildAgent::getId).collect(Collectors.toSet());
+    Collection<BuildAgentEx> unauthorized = myBuildAgentManager.getAllAgents(true)
+            .stream()
+            .filter(agent -> !authorizedIds.contains(agent.getId()))
+            .collect(Collectors.toList());
     unauthorized.removeAll(authorized);
     model.put("unauthorizedAgents", unauthorized);
 


### PR DESCRIPTION
Caused by missing `equals` methods in `BuildAgentEx` implementations.
Also changed project language level to Java 1.8, since we target TeamCity 10.0+ from now